### PR TITLE
Fix EmpiricalLightModel using headlightMaxTxAngle for tail light

### DIFF
--- a/src/veins-vlc/analogueModel/EmpiricalLightModel.cc
+++ b/src/veins-vlc/analogueModel/EmpiricalLightModel.cc
@@ -2108,7 +2108,7 @@ void EmpiricalLightModel::filterSignal(Signal* signal)
     }
     case TAIL: {
         bool inTxRange = tx2RxDistance <= taillightMaxTxRange;
-        bool inTxFov = ((receiverPos2D - senderPos2D) / cos(headlightMaxTxAngle)) * txHeadingVector >= tx2RxDistance;
+        bool inTxFov = ((receiverPos2D - senderPos2D) / cos(taillightMaxTxAngle)) * txHeadingVector >= tx2RxDistance;
         bool inTxBearing = cosIncidenceAngle < 0;
 
         // Debug messages


### PR DESCRIPTION
From my reading of <https://github.com/veins/veins_vlc/blob/veins-vlc-1.0/src/veins-vlc/analogueModel/EmpiricalLightModel.cc#L2111>, it seems like the EmpiricalLightModel observes headlightMaxTxAngle as the maximum angle also for txOrientation == TAIL (that is, for ccTailModel).

If I am reading <https://github.com/veins/veins_vlc/blob/veins-vlc-1.0/src/veins-vlc/analogueModel/EmpiricalLightModel.h#L74> right, the model implies that this could be set with taillightMaxTxAngle (instead of headlightMaxTxAngle).

This PR changes the tail light to use taillightMaxTxAngle instead.