### PR TITLE
Adapt message type check to changed name

### DIFF
--- a/src/veins-vlc/Splitter.cc
+++ b/src/veins-vlc/Splitter.cc
@@ -107,12 +107,12 @@ void Splitter::handleUpperMessage(cMessage* msg)
         BaseFrame1609_4* wsm = dynamic_cast<BaseFrame1609_4*>(msg);
 
         // If not a VlcMessage check whether it is a WSM to send directly
-        if (wsm != NULL && !strcmp(msg->getClassName(), "WaveShortMessage")) {
+        if (wsm) {
             send(wsm, toDsrcNic);
             return;
         }
         else
-            error("Not a VlcMessage, not WaveShortMessage");
+            error("Not a VlcMessage, not BaseFrame1609_4");
     }
 
     // if (vlcMsg)...


### PR DESCRIPTION
The splitter checks that only BaseFrame1609_4s can be sent. These have been recently renamed, which causes issues when sending a non-`VlcMessage` via the Splitter as the classname comparison will fail. This PR removes the check additional check on the classname and adapts the error message in case the cast fails to reflect the new message name.