### PR TITLE
Add default value for expected TX power

### DIFF
--- a/src/veins-vlc/PhyLayerVlc.ned
+++ b/src/veins-vlc/PhyLayerVlc.ned
@@ -30,7 +30,7 @@ simple PhyLayerVlc extends BasePhyLayer
         //enabling this feature increases simulation time
         bool collectCollisionStatistics = default(false);
         
-        double txPower @unit(mW);
+        double txPower @unit(mW) = default(10mW);
         double bitrate @unit(bps);
 
         // Parameters for LsvLightModel


### PR DESCRIPTION
Veins' `BasePhyLayer` requires the TX power to be configured in derived specific Phy layers. For Veins VLC, there is no sensible value to use, since the models are based on empirical measurements. However, the code asserts, that it is set to the used reference power, i.e., 10mW. This can lead to wrong expectations when using the code, therefore, this PR sets the parameter's default value to the expected one, such that it doesn't have to be explicitly set by the user.