### PR TITLE
Remove unused VLC message member broadcastId

### DIFF
--- a/src/veins-vlc/messages/VlcMessage.msg
+++ b/src/veins-vlc/messages/VlcMessage.msg
@@ -38,5 +38,4 @@ message VlcMessage extends veins::BaseFrame1609_4 {
 	int accessTechnology;
 	int transmissionModule;	// Tell the middle layer which transmission module to use
 	simtime_t sentAt;
-	int broadcastId = -1;
 }


### PR DESCRIPTION
The proposed patch removes an unused field from the `VlcMessage` definition.