### PR TITLE
Remove redundant VlcMessage field sentAt

### DIFF
--- a/src/veins-vlc/Splitter.cc
+++ b/src/veins-vlc/Splitter.cc
@@ -186,16 +186,16 @@ void Splitter::handleLowerMessage(cMessage* msg)
         vlcPacketsReceived++;
         VlcMessage* vlcMsg = dynamic_cast<VlcMessage*>(msg);
 
-        emit(totalVlcDelaySignal, simTime() - vlcMsg->getSentAt());
+        emit(totalVlcDelaySignal, simTime() - vlcMsg->getCreationTime());
 
         int srclightModule = vlcMsg->getTransmissionModule();
         if (srclightModule == HEADLIGHT) {
             headlightPacketsReceived++;
-            emit(headVlcDelaySignal, simTime() - vlcMsg->getSentAt());
+            emit(headVlcDelaySignal, simTime() - vlcMsg->getCreationTime());
         }
         else if (srclightModule == TAILLIGHT) {
             taillightPacketsReceived++;
-            emit(tailVlcDelaySignal, simTime() - vlcMsg->getSentAt());
+            emit(tailVlcDelaySignal, simTime() - vlcMsg->getCreationTime());
         }
         else
             error("neither `head` nor `tail`");

--- a/src/veins-vlc/application/simpleVlcApp/SimpleVlcApp.cc
+++ b/src/veins-vlc/application/simpleVlcApp/SimpleVlcApp.cc
@@ -118,7 +118,6 @@ VlcMessage* SimpleVlcApp::generateVlcMessage(int accessTechnology, int sendingMo
     vlcMsg->setDestinationNode("BROADCAST");
     vlcMsg->setAccessTechnology(accessTechnology);
     vlcMsg->setTransmissionModule(sendingModule);
-    vlcMsg->setSentAt(simTime()); // There is timestamp field in WSM too
 
     // Set application layer packet length
     vlcMsg->setByteLength(byteLength);

--- a/src/veins-vlc/messages/VlcMessage.msg
+++ b/src/veins-vlc/messages/VlcMessage.msg
@@ -37,5 +37,4 @@ message VlcMessage extends veins::BaseFrame1609_4 {
 	string destinationNode;		
 	int accessTechnology;
 	int transmissionModule;	// Tell the middle layer which transmission module to use
-	simtime_t sentAt;
 }


### PR DESCRIPTION
`cMessages` already provide the same functionality via the
`getCreationTime()` method.