### PR TITLE
Cope with multiple transmissions and communicate incoming interface to upper layers

### DIFF
--- a/src/veins-vlc/Splitter.cc
+++ b/src/veins-vlc/Splitter.cc
@@ -199,6 +199,12 @@ void Splitter::handleLowerMessage(cMessage* msg)
         }
         else
             error("neither `head` nor `tail`");
+
+    }
+
+    if (VlcMessage* vlcMsg = dynamic_cast<VlcMessage*>(msg)) {
+        if (lowerGate == fromVlcHead) vlcMsg->setTransmissionModule(HEADLIGHT);
+        if (lowerGate == fromVlcTail) vlcMsg->setTransmissionModule(TAILLIGHT);
     }
 
     send(msg, toApplication);

--- a/src/veins-vlc/mac/MacLayerVlc.cc
+++ b/src/veins-vlc/mac/MacLayerVlc.cc
@@ -51,23 +51,22 @@ void MacLayerVlc::handleUpperMsg(cMessage* msg)
     EV_TRACE << "Received a message from upper layer" << std::endl;
     ASSERT(dynamic_cast<cPacket*>(msg));
 
-    sendDown(encapsMsg(check_and_cast<cPacket*>(msg)));
-
-    // if (transmitting) {
-    //    enqueuePacket(check_and_cast<cPacket*>(msg));
-    // }
-    // else {
-    //    sendDown(encapsMsg(check_and_cast<cPacket*>(msg)));
-    //    transmitting = true;
-    // }
+    if (transmitting) {
+        enqueuePacket(check_and_cast<cPacket*>(msg));
+    }
+    else {
+        if (!queue.isEmpty()) throw cRuntimeError("Radio not transmitting but packets in queue");
+        sendDown(encapsMsg(check_and_cast<cPacket*>(msg)));
+        transmitting = true;
+    }
 }
 
 void MacLayerVlc::handleLowerControl(cMessage* msg)
 {
     switch (msg->getKind()) {
     case MacToPhyInterface::TX_OVER:
-        // transmitting = false;
-        // transmissionOpportunity();
+        transmitting = false;
+        transmissionOpportunity();
         delete msg;
         break;
     default:


### PR DESCRIPTION
This PR includes two commits:

- b39c654 re-enables the logic that was checking whether a transmission was already ongoing. For some reason unknown to me this portion of the code was commented out, causing the simulation to crash if a message was sent to the NIC for transmission while another transmission was being performed
- 936b9ef is more of a utility for upper layers. It stores inside the `VlcMessage` the VLC interface the message was received from