### PR TITLE
Introduce splitter interface

### DIFF
--- a/src/veins-vlc/ISplitter.ned
+++ b/src/veins-vlc/ISplitter.ned
@@ -1,7 +1,5 @@
 //
-// Copyright (C) 2017 Agon Memedi <memedi@ccs-labs.org>
-//
-// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2006-2017 Agon Memedi <memedi@ccs-labs.org>
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -18,35 +16,9 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 //
 
-// This module accepts packets from the application layer and distributes 
-// it to the correct NIC based on the tagging on thhe packet coming 
-// from the application layer. Recorgnizes both WSMs and VLC Messages 
-// coming from the upper layers. 
-//    
-// For the messages coming from the lower layer NICs, it just sends the
-// message to the application; it is the taks of the application to
-// figure out if the message is a WSM or a VLC Message, in case of need
-        
 package org.car2x.veinsvlc;
 
-simple Splitter like ISplitter {
-    parameters:
-        @class(veins::Splitter);
-        bool debug = default(false);
-        bool draw = default(false);
-        bool collectStatistics = default(false);
-        double drawHeadHalfAngle = default(0) @unit(deg);
-        double drawTailHalfAngle = default(0) @unit(deg);
-        
-        @signal[totalVlcDelay](type="simtime_t");
-        @statistic[totalVlcDelay](record=mean);
-        
-        @signal[headVlcDelay](type="simtime_t");
-        @statistic[headVlcDelay](record=mean);
-        
-        @signal[tailVlcDelay](type="simtime_t");
-        @statistic[tailVlcDelay](record=mean);
-          
+moduleinterface ISplitter {
     gates:
         output applicationOut;  // output gate towards the application
         input applicationIn;    // input gate from the application

--- a/src/veins-vlc/Splitter.cc
+++ b/src/veins-vlc/Splitter.cc
@@ -94,25 +94,20 @@ void Splitter::handleUpperMessage(cMessage* msg)
 
     // Handle WSMs if the VLC has to be "retrofitted" to non-VLC app
     if (!vlcMsg) {
-        BaseFrame1609_4* wsm = dynamic_cast<BaseFrame1609_4*>(msg);
-
-        // If not a VlcMessage check whether it is a WSM to send directly
-        if (wsm) {
-            send(wsm, toDsrcNic);
-            return;
-        }
-        else
-            error("Not a VlcMessage, not BaseFrame1609_4");
+        BaseFrame1609_4* wsm = check_and_cast<BaseFrame1609_4*>(msg);
+        send(wsm, toDsrcNic);
+        return;
     }
 
     // if (vlcMsg)...
-    int networkType = vlcMsg->getAccessTechnology();
-    if (networkType == DSRC) {
+    const auto accessTechnology = static_cast<Splitter::Interfaces>(vlcMsg->getAccessTechnology());
+    if (accessTechnology.test(Splitter::Interface::dsrc)) {
         EV_INFO << "DSRC message received from upper layer!" << std::endl;
-        send(vlcMsg, toDsrcNic);
+        send(vlcMsg->dup(), toDsrcNic);
     }
-    else if (networkType == VLC) {
-        EV_INFO << "VLC message received from upper layer!" << std::endl;
+    if (accessTechnology.test(Splitter::Interface::vlc_head)) {
+        EV_INFO << "VLC head message received from upper layer!" << std::endl;
+
         if (draw) {
             // Won't draw at simTime() < 0.1 as TraCI is not connected and annotation fails
             auto drawCones = [this]() {
@@ -120,6 +115,18 @@ void Splitter::handleUpperMessage(cMessage* msg)
                 drawRayLine(vlcPhys[0]->getAntennaPosition(), 100, headHalfAngle);
                 // left
                 drawRayLine(vlcPhys[0]->getAntennaPosition(), 100, -headHalfAngle);
+            };
+            // The cones will be drawn immediately as a message is received from the layer above
+            timerManager.create(veins::TimerSpecification(drawCones).oneshotAt(simTime()));
+        }
+        headlightPacketsSent += 1;
+        vlcPacketsSent += 1;
+        send(vlcMsg->dup(), toVlcHead);
+    }
+    if (accessTechnology.test(Splitter::Interface::vlc_tail)) {
+        EV_INFO << "VLC tail message received from upper layer!" << std::endl;
+        if (draw) {
+            auto drawCones = [this]() {
                 // Taillight, left
                 drawRayLine(vlcPhys[1]->getAntennaPosition(), 30, tailHalfAngle, true);
                 // right
@@ -129,72 +136,37 @@ void Splitter::handleUpperMessage(cMessage* msg)
             timerManager.create(veins::TimerSpecification(drawCones).oneshotAt(simTime()));
         }
 
-        int lightModule = vlcMsg->getTransmissionModule();
-
-        switch (lightModule) {
-        case HEADLIGHT:
-            headlightPacketsSent++;
-            send(vlcMsg, toVlcHead);
-            break;
-        case TAILLIGHT:
-            taillightPacketsSent++;
-            send(vlcMsg, toVlcTail);
-            break;
-        case DONT_CARE:
-            error("behavior not specified for DONT_CARE");
-            break;
-        case BOTH_LIGHTS: {
-            vlcPacketsSent++;
-            VlcMessage* toHead = vlcMsg->dup();
-            toHead->setTransmissionModule(HEADLIGHT);
-            send(toHead, toVlcHead);
-
-            VlcMessage* toTail = vlcMsg->dup();
-            toTail->setTransmissionModule(TAILLIGHT);
-            send(toTail, toVlcTail);
-            delete vlcMsg;
-            vlcMsg = NULL;
-            break;
-        }
-        default:
-            error("\tThe light module has not been specified in the message!");
-            break;
-        }
+        taillightPacketsSent += 1;
+        vlcPacketsSent += 1;
+        send(vlcMsg->dup(), toVlcTail);
     }
-    else {
-        error("\tThe access technology has not been specified in the message!");
-    }
+
+    delete msg;
 }
 
 void Splitter::handleLowerMessage(cMessage* msg)
 {
-    int lowerGate = msg->getArrivalGateId();
-
-    // !(lowerGate == fromDsrcNic) --> (lowerGate  == fromVlcHead || fromVlcTail)
-    // If the message is from any of the VLC modules and we need to collect statistics
-    if (!(lowerGate == fromDsrcNic) && collectStatistics) {
-        vlcPacketsReceived++;
-        VlcMessage* vlcMsg = dynamic_cast<VlcMessage*>(msg);
-
-        emit(totalVlcDelaySignal, simTime() - vlcMsg->getCreationTime());
-
-        int srclightModule = vlcMsg->getTransmissionModule();
-        if (srclightModule == HEADLIGHT) {
-            headlightPacketsReceived++;
-            emit(headVlcDelaySignal, simTime() - vlcMsg->getCreationTime());
+    if (msg->getArrivalGateId() == fromDsrcNic) {
+        headlightPacketsReceived++;
+        if (VlcMessage* vlcMsg = dynamic_cast<VlcMessage*>(msg)) {
+            vlcMsg->setAccessTechnology(Splitter::Interfaces(Splitter::Interface::dsrc).to_ulong());
         }
-        else if (srclightModule == TAILLIGHT) {
-            taillightPacketsReceived++;
-            emit(tailVlcDelaySignal, simTime() - vlcMsg->getCreationTime());
+    } else if (msg->getArrivalGateId() == fromVlcHead) {
+        headlightPacketsReceived += 1;
+        vlcPacketsReceived += 1;
+        emit(headVlcDelaySignal, simTime() - msg->getCreationTime());
+        emit(totalVlcDelaySignal, simTime() - msg->getCreationTime());
+        if (VlcMessage* vlcMsg = dynamic_cast<VlcMessage*>(msg)) {
+            vlcMsg->setAccessTechnology(Splitter::Interfaces(Splitter::Interface::vlc_head).to_ulong());
         }
-        else
-            error("neither `head` nor `tail`");
-
-    }
-
-    if (VlcMessage* vlcMsg = dynamic_cast<VlcMessage*>(msg)) {
-        if (lowerGate == fromVlcHead) vlcMsg->setTransmissionModule(HEADLIGHT);
-        if (lowerGate == fromVlcTail) vlcMsg->setTransmissionModule(TAILLIGHT);
+    } else if (msg->getArrivalGateId() == fromVlcTail) {
+        taillightPacketsReceived += 1;
+        vlcPacketsReceived += 1;
+        emit(tailVlcDelaySignal, simTime() - msg->getCreationTime());
+        emit(totalVlcDelaySignal, simTime() - msg->getCreationTime());
+        if (VlcMessage* vlcMsg = dynamic_cast<VlcMessage*>(msg)) {
+            vlcMsg->setAccessTechnology(Splitter::Interfaces(Splitter::Interface::vlc_tail).to_ulong());
+        }
     }
 
     send(msg, toApplication);

--- a/src/veins-vlc/Splitter.cc
+++ b/src/veins-vlc/Splitter.cc
@@ -54,8 +54,7 @@ void Splitter::initialize()
     tailVlcDelaySignal = registerSignal("tailVlcDelay");
 
     // Other simulation modules
-    cModule* tmpMobility = getParentModule()->getSubmodule("veinsmobility");
-    mobility = dynamic_cast<TraCIMobility*>(tmpMobility);
+    mobility = FindModule<TraCIMobility*>::findSubModule(getParentModule());
     ASSERT(mobility);
 
     vlcPhys = getSubmodulesOfType<PhyLayerVlc>(getParentModule(), true);

--- a/src/veins-vlc/Splitter.cc
+++ b/src/veins-vlc/Splitter.cc
@@ -26,16 +26,6 @@ using namespace veins;
 
 Define_Module(veins::Splitter);
 
-Splitter::Splitter()
-    : annotationManager(NULL)
-
-{
-}
-
-Splitter::~Splitter()
-{
-}
-
 void Splitter::initialize()
 {
     // From upper layers --> lower layers

--- a/src/veins-vlc/Splitter.h
+++ b/src/veins-vlc/Splitter.h
@@ -37,7 +37,7 @@ namespace veins {
 class Splitter : public cSimpleModule {
 public:
     Splitter() {}
-    ~Splitter() {}
+    virtual ~Splitter() {}
 
 protected:
     // Gates

--- a/src/veins-vlc/Splitter.h
+++ b/src/veins-vlc/Splitter.h
@@ -23,6 +23,7 @@
 #include <omnetpp.h>
 
 #include "veins/modules/mobility/traci/TraCIMobility.h"
+#include "veins/base/utils/EnumBitset.h"
 #include "veins/modules/utility/TimerManager.h"
 #include "veins/modules/world/annotations/AnnotationManager.h"
 
@@ -36,6 +37,13 @@ namespace veins {
 
 class Splitter : public cSimpleModule {
 public:
+    enum class Interface : uint32_t {
+        dsrc,
+        vlc_head,
+        vlc_tail
+    };
+    using Interfaces = veins::EnumBitset<Interface>;
+
     Splitter() {}
     virtual ~Splitter() {}
 
@@ -81,6 +89,11 @@ protected:
     void handleLowerMessage(cMessage* msg);
 
     void drawRayLine(const AntennaPosition& ap, int length, double halfAngle, bool reverse = false);
+};
+
+template <>
+struct EnumTraits<Splitter::Interface> {
+    static const Splitter::Interface max = Splitter::Interface::vlc_tail;
 };
 
 } // namespace veins

--- a/src/veins-vlc/Splitter.h
+++ b/src/veins-vlc/Splitter.h
@@ -87,6 +87,7 @@ protected:
     virtual void finish();
     void handleUpperMessage(cMessage* msg);
     void handleLowerMessage(cMessage* msg);
+    virtual Interfaces getAccessTechnology(cPacket *msg);
 
     void drawRayLine(const AntennaPosition& ap, int length, double halfAngle, bool reverse = false);
 };

--- a/src/veins-vlc/Splitter.h
+++ b/src/veins-vlc/Splitter.h
@@ -36,8 +36,8 @@ namespace veins {
 
 class Splitter : public cSimpleModule {
 public:
-    Splitter();
-    ~Splitter();
+    Splitter() {}
+    ~Splitter() {}
 
 protected:
     // Gates
@@ -56,8 +56,8 @@ protected:
     bool draw;
     double headHalfAngle;
     double tailHalfAngle;
-    TraCIMobility* mobility;
-    AnnotationManager* annotationManager;
+    TraCIMobility* mobility = nullptr;
+    AnnotationManager* annotationManager = nullptr;
     veins::TimerManager timerManager{this};
     std::vector<PhyLayerVlc*> vlcPhys;
 

--- a/src/veins-vlc/application/simpleVlcApp/SimpleVlcApp.h
+++ b/src/veins-vlc/application/simpleVlcApp/SimpleVlcApp.h
@@ -66,7 +66,7 @@ public:
     }
 
 protected:
-    VlcMessage* generateVlcMessage(int accessTechnology, int sendingModule);
+    VlcMessage* generateVlcMessage(int accessTechnology);
 };
 
 } // namespace veins

--- a/src/veins-vlc/messages/VlcMessage.msg
+++ b/src/veins-vlc/messages/VlcMessage.msg
@@ -20,21 +20,12 @@
 
 cplusplus {{
 #include "veins/modules/messages/BaseFrame1609_4_m.h"
-
-#define VLC 30
-#define DSRC 31
-
-#define	DONT_CARE 310
-#define HEADLIGHT 311
-#define TAILLIGHT 312
-#define BOTH_LIGHTS 313	// Middleware will create two copies of the same message; One sent via HEADLIGHT, one sent via TAILLIGHT.   
 }}
 
-class veins::BaseFrame1609_4;	
+class veins::BaseFrame1609_4;   
 
 message VlcMessage extends veins::BaseFrame1609_4 {
-	string sourceNode;
-	string destinationNode;		
-	int accessTechnology;
-	int transmissionModule;	// Tell the middle layer which transmission module to use
+    string sourceNode;
+    string destinationNode;     
+    int accessTechnology;
 }


### PR DESCRIPTION
This PR introduces changes that rework the existing splitter to make it more easily usable. The result is a splitter that can be inherited from where subclasses can compute which of the interfaces should be used for each given message. The base implementation has the same behavior as the current splitter, however, the application does not _have_ to specify the interface to use with the `VlcMessage`.

To make this work, I refactored the existing constants, I dropped the integer definitions used to code interfaces in favor of a bitset the splitter defines. This means existing code will have to be adapted, the previous `transmissionTechnology` and `headOrTail` members have been replaced by a `accessTechnology` member that encodes both, and is more flexible (e.g., it is possible to send a packet via DSRC and the taillight. The changes to the `SimpleVlcApp` should be a good example of how this looks now.

I have used this code for my simulations, and reran the example with Veins 5.0 to confirm that it works.